### PR TITLE
Immersive Portal Compat

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -19,11 +19,50 @@ configurations {
     developmentFabric.extendsFrom common
 }
 
+repositories {
+    if (project.immptl_fix) {
+        // the repository for ImmPtl
+        maven { url 'https://jitpack.io' }
+
+        // the repository for Cloth Config
+        maven { url 'https://maven.shedaniel.me' }
+    }
+}
+
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
+
+    if (project.immptl_fix) {
+        // Dependency of Immersive Portals Core:
+        modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:imm_ptl_core:${project.immptl_version}"){
+            exclude(group: "net.fabricmc.fabric-api")
+            transitive(false)
+        }
+
+        // Dependency of the Miscellaneous Utility Library from qouteall
+        modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:q_misc_util:${project.immptl_version}"){
+            exclude(group: "net.fabricmc.fabric-api")
+            transitive(false)
+        }
+
+        // Cloth config (dependency of ImmPtl)
+        modImplementation("me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}") {
+            exclude(group: "net.fabricmc.fabric-api")
+        }
+
+        // If you want the outer Immersive Portals mod (This is usually not needed)
+        modImplementation ("com.github.iPortalTeam.ImmersivePortalsMod:build:${project.immptl_version}"){
+            exclude(group: "net.fabricmc.fabric-api")
+            transitive(false)
+        }
+
+        // immptl stuff
+        api("com.github.LlamaLad7:MixinExtras:${project.mixin_extras_version}")
+        annotationProcessor("com.github.LlamaLad7:MixinExtras:${project.mixin_extras_version}")
+    }
 }
 
 processResources {

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,0 +1,4 @@
+immptl_fix=true
+immptl_version=v3.2.6-mc1.20.1
+cloth_config_version=11.0.99
+mixin_extras_version=0.2.0-beta.9

--- a/fabric/src/main/java/dev/schmarrn/lighty/fabric/mixin/ConditionalMixinPlugin.java
+++ b/fabric/src/main/java/dev/schmarrn/lighty/fabric/mixin/ConditionalMixinPlugin.java
@@ -1,0 +1,49 @@
+package dev.schmarrn.lighty.fabric.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class ConditionalMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (targetClassName.equals("dev.schmarrn.lighty.fabric.mixin.ImmPtlFix")) {
+            return FabricLoader.getInstance().isModLoaded("imm_ptl_core");
+        }
+        return false;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/fabric/src/main/java/dev/schmarrn/lighty/fabric/mixin/ImmPtlFix.java
+++ b/fabric/src/main/java/dev/schmarrn/lighty/fabric/mixin/ImmPtlFix.java
@@ -1,0 +1,30 @@
+// Copyright 2022-2023 The Lighty contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dev.schmarrn.lighty.fabric.mixin;
+
+import dev.schmarrn.lighty.event.Compute;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.LightLayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(qouteall.imm_ptl.core.chunk_loading.ImmPtlClientChunkMap.class)
+public class ImmPtlFix {
+    @Inject(method = "onLightUpdate", at = @At("TAIL"))
+    private void lighty$onBlockUpdate(LightLayer lightLayer, SectionPos sectionPos, CallbackInfo ci) {
+        Compute.updateSubChunk(sectionPos);
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,7 +22,8 @@
     ]
   },
   "mixins": [
-    "lighty.mixins.json"
+    "lighty.mixins.json",
+    "lighty.fabric.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.14.21",

--- a/fabric/src/main/resources/lighty.fabric.mixins.json
+++ b/fabric/src/main/resources/lighty.fabric.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "dev.schmarrn.lighty.fabric.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "plugin": "dev.schmarrn.lighty.fabric.mixin.ConditionalMixinPlugin",
+  "client": [
+    "ImmPtlFix"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ maven_group=dev.schmarrn
 archives_base_name=lighty
 
 fabric_loader_version=0.14.21
-fabric_api_version=0.83.1+1.20.1
+fabric_api_version=0.87.0+1.20.1
 
 forge_version=1.20.1-47.0.1


### PR DESCRIPTION
It is broken in different ways now, the fix was not as easy as I hoped it would be.

There are problems with caching the chunks, nether overlay gets rendered in overworld and vice versa.
![image](https://github.com/SchmarrnDevs/Lighty/assets/26302678/64dbf3df-c5c6-4ff3-818c-e3e34dac0312)


I would still need to figure out how to tell gradle how to exclude some classes too.

I invite every dev interested in making immptl compat work to start of this code, for me this is very low priority.
Feel free to message me or leave a message on this PR if you want to work on it.

Would resolve #29 

