### PR TITLE
Implemented dimension-specific light thresholds

### DIFF
--- a/common/src/main/java/dev/schmarrn/lighty/api/LightyColors.java
+++ b/common/src/main/java/dev/schmarrn/lighty/api/LightyColors.java
@@ -55,13 +55,31 @@ public class LightyColors {
         return RED  | 0xFF000000;
     }
 
-    public static int getARGB(int blockLightLevel, int skyLightLevel) {
-        // Artificial light is always safe
-        if (blockLightLevel > Config.getBlockThreshold()) return LightyColors.getSafeARGB();
-        // If we don't have artificial lighting, mobs can spawn at night
-        if (skyLightLevel > Config.getSkyThreshold()) return LightyColors.getWarningARGB();
-        // Without artificial nor skylight, mobs can always spawn
-        return LightyColors.getDangerARGB();
+    public static int getARGB(int blockLightLevel, int skyLightLevel, String dimension) {
+        switch (dimension) {
+            case "minecraft:the_nether":
+                // Artificial light is always safe
+                if (blockLightLevel > Config.getNetherBlockThreshold()) return LightyColors.getSafeARGB();
+                // If we don't have artificial lighting, mobs can spawn at night
+                if (skyLightLevel > Config.getNetherSkyThreshold()) return LightyColors.getWarningARGB();
+                // Without artificial nor skylight, mobs can always spawn
+                return LightyColors.getDangerARGB();
+            case "minecraft:the_end":
+                // Artificial light is always safe
+                if (blockLightLevel > Config.getEndBlockThreshold()) return LightyColors.getSafeARGB();
+                // If we don't have artificial lighting, mobs can spawn at night
+                if (skyLightLevel > Config.getEndSkyThreshold()) return LightyColors.getWarningARGB();
+                // Without artificial nor skylight, mobs can always spawn
+                return LightyColors.getDangerARGB();
+            default:
+                // Use "minecraft:overworld" for all other cases
+                // Artificial light is always safe
+                if (blockLightLevel > Config.getOverworldBlockThreshold()) return LightyColors.getSafeARGB();
+                // If we don't have artificial lighting, mobs can spawn at night
+                if (skyLightLevel > Config.getOverworldSkyThreshold()) return LightyColors.getWarningARGB();
+                // Without artificial nor skylight, mobs can always spawn
+                return LightyColors.getDangerARGB();
+        }
     }
 
     public static int getGrowthARGB(int blockLightLevel, int skyLightLevel) {

--- a/common/src/main/java/dev/schmarrn/lighty/api/LightyHelper.java
+++ b/common/src/main/java/dev/schmarrn/lighty/api/LightyHelper.java
@@ -68,6 +68,6 @@ public class LightyHelper {
     }
 
     public static boolean isSafe(int blockLightLevel) {
-        return !(blockLightLevel <= Config.getBlockThreshold());
+        return !(blockLightLevel <= Config.getOverworldBlockThreshold());
     }
 }

--- a/common/src/main/java/dev/schmarrn/lighty/config/Config.java
+++ b/common/src/main/java/dev/schmarrn/lighty/config/Config.java
@@ -29,9 +29,20 @@ public class Config {
 
     private static Config config;
 
+    private static final String overworld_block_threshold_value = "0";
+    private static final String overworld_sky_threshold_value = "7";
+    private static final String nether_block_threshold_value = "11";
+    private static final String nether_sky_threshold_value = overworld_sky_threshold_value;
+    private static final String end_block_threshold_value = "0";
+    private static final String end_sky_threshold_value = overworld_sky_threshold_value;
+
     private static final String LAST_USED_MODE = "lighty.last_used_mode";
-    private static final String SKY_THRESHOLD = "lighty.sky_threshold";
-    private static final String BLOCK_THRESHOLD = "lighty.block_threshold";
+    private static final String OVERWORLD_BLOCK_THRESHOLD = "lighty.block_threshold";
+    private static final String OVERWORLD_SKY_THRESHOLD = "lighty.sky_threshold";
+    private static final String NETHER_BLOCK_THRESHOLD = "lighty.nether_block_threshold";
+    private static final String NETHER_SKY_THRESHOLD = "lighty.nether_sky_threshold";
+    private static final String END_BLOCK_THRESHOLD = "lighty.nether_block_threshold";
+    private static final String END_SKY_THRESHOLD = "lighty.nether_sky_threshold";
     private static final String FARM_GROWTH_THRESHOLD = "lighty.farm_growth_threshold";
     private static final String FARM_UPROOT_THRESHOLD = "lighty.farm_uproot_threshold";
     private static final String OVERLAY_DISTANCE = "lighty.overlay_distance";
@@ -50,8 +61,8 @@ public class Config {
 
             // Set Defaults if no values are set
             properties.putIfAbsent(LAST_USED_MODE, "lighty:carpet_mode");
-            properties.putIfAbsent(SKY_THRESHOLD, "0");
-            properties.putIfAbsent(BLOCK_THRESHOLD, "0");
+            properties.putIfAbsent(OVERWORLD_BLOCK_THRESHOLD, overworld_block_threshold_value);
+            properties.putIfAbsent(OVERWORLD_SKY_THRESHOLD, overworld_sky_threshold_value);
             properties.putIfAbsent(FARM_GROWTH_THRESHOLD, "8");
             properties.putIfAbsent(FARM_UPROOT_THRESHOLD, "8");
             properties.putIfAbsent(OVERLAY_DISTANCE, "2");
@@ -65,8 +76,8 @@ public class Config {
 
             // Add Defaults here
             properties.setProperty(LAST_USED_MODE, "lighty:carpet_mode");
-            properties.setProperty(SKY_THRESHOLD, "0");
-            properties.setProperty(BLOCK_THRESHOLD, "0");
+            properties.setProperty(OVERWORLD_BLOCK_THRESHOLD, overworld_block_threshold_value);
+            properties.setProperty(OVERWORLD_SKY_THRESHOLD, overworld_sky_threshold_value);
             properties.setProperty(FARM_GROWTH_THRESHOLD, "8");
             properties.setProperty(FARM_UPROOT_THRESHOLD, "8");
             properties.setProperty(OVERLAY_DISTANCE, "2");
@@ -91,12 +102,28 @@ public class Config {
         }
     }
 
-    public static int getSkyThreshold() {
-        return Integer.parseInt(config.properties.getProperty(SKY_THRESHOLD, "0"));
+    public static int getOverworldBlockThreshold() {
+        return Integer.parseInt(config.properties.getProperty(OVERWORLD_BLOCK_THRESHOLD, overworld_block_threshold_value));
     }
 
-    public static int getBlockThreshold() {
-        return Integer.parseInt(config.properties.getProperty(BLOCK_THRESHOLD, "0"));
+    public static int getOverworldSkyThreshold() {
+        return Integer.parseInt(config.properties.getProperty(OVERWORLD_SKY_THRESHOLD, overworld_sky_threshold_value));
+    }
+
+    public static int getNetherBlockThreshold() {
+        return Integer.parseInt(config.properties.getProperty(NETHER_BLOCK_THRESHOLD, nether_block_threshold_value));
+    }
+
+    public static int getNetherSkyThreshold() {
+        return Integer.parseInt(config.properties.getProperty(NETHER_SKY_THRESHOLD, nether_sky_threshold_value));
+    }
+
+    public static int getEndBlockThreshold() {
+        return Integer.parseInt(config.properties.getProperty(END_BLOCK_THRESHOLD, end_block_threshold_value));
+    }
+
+    public static int getEndSkyThreshold() {
+        return Integer.parseInt(config.properties.getProperty(END_SKY_THRESHOLD, end_sky_threshold_value));
     }
 
     public static int getFarmGrowthThreshold() {
@@ -127,13 +154,13 @@ public class Config {
         config.write();
     }
 
-    public static void setSkyThreshold(int i) {
-        config.properties.setProperty(SKY_THRESHOLD, String.valueOf(i));
+    public static void setOverworldBlockThreshold(int i) {
+        config.properties.setProperty(OVERWORLD_BLOCK_THRESHOLD, String.valueOf(i));
         config.write();
     }
 
-    public static void setBlockThreshold(int i) {
-        config.properties.setProperty(BLOCK_THRESHOLD, String.valueOf(i));
+    public static void setOverworldSkyThreshold(int i) {
+        config.properties.setProperty(OVERWORLD_SKY_THRESHOLD, String.valueOf(i));
         config.write();
     }
 

--- a/common/src/main/java/dev/schmarrn/lighty/mode/BoringCrossMode.java
+++ b/common/src/main/java/dev/schmarrn/lighty/mode/BoringCrossMode.java
@@ -45,12 +45,13 @@ public class BoringCrossMode extends LightyMode {
         if (!LightyHelper.isBlocked(world.getBlockState(pos.below()), pos, world)) {
             int blockLightLevel = world.getBrightness(LightLayer.BLOCK, pos);
             int skyLightLevel = world.getBrightness(LightLayer.SKY, pos);
+            String dimensionName = world.dimensionType().effectsLocation().toString();
 
             if (LightyHelper.isSafe(blockLightLevel) && !Config.getShowSafe()) {
                 return;
             }
 
-            int color = LightyColors.getARGB(blockLightLevel, skyLightLevel);
+            int color = LightyColors.getARGB(blockLightLevel, skyLightLevel, dimensionName);
 
             float offset = LightyHelper.getOffset(blockState, pos, world);
             if (offset == -1f) {

--- a/common/src/main/java/dev/schmarrn/lighty/mode/CarpetMode.java
+++ b/common/src/main/java/dev/schmarrn/lighty/mode/CarpetMode.java
@@ -52,12 +52,13 @@ public class CarpetMode extends LightyMode {
 
         int blockLightLevel = world.getBrightness(LightLayer.BLOCK, posUp);
         int skyLightLevel = world.getBrightness(LightLayer.SKY, posUp);
+        String dimensionName = world.dimensionType().effectsLocation().toString();
 
         if (LightyHelper.isSafe(blockLightLevel) && !Config.getShowSafe()) {
             return;
         }
 
-        int color = LightyColors.getARGB(blockLightLevel, skyLightLevel);
+        int color = LightyColors.getARGB(blockLightLevel, skyLightLevel, dimensionName);
 
         double offset = LightyHelper.getOffset(blockState, pos, world);
         if (offset == -1f) {

--- a/common/src/main/java/dev/schmarrn/lighty/mode/NumberMode.java
+++ b/common/src/main/java/dev/schmarrn/lighty/mode/NumberMode.java
@@ -94,12 +94,13 @@ public class NumberMode extends LightyMode {
 
         int blockLightLevel = world.getBrightness(LightLayer.BLOCK, posUp);
         int skyLightLevel = world.getBrightness(LightLayer.SKY, posUp);
+        String dimensionName = world.dimensionType().effectsLocation().toString();
 
         if (LightyHelper.isSafe(blockLightLevel) && !Config.getShowSafe()) {
             return;
         }
 
-        int color = LightyColors.getARGB(blockLightLevel, skyLightLevel);
+        int color = LightyColors.getARGB(blockLightLevel, skyLightLevel, dimensionName);
 
         float offset = LightyHelper.getOffset(blockState, pos, world);
         if (offset == -1f) {

--- a/common/src/main/java/dev/schmarrn/lighty/ui/SettingsScreen.java
+++ b/common/src/main/java/dev/schmarrn/lighty/ui/SettingsScreen.java
@@ -68,8 +68,8 @@ public class SettingsScreen extends Screen {
                                 (component, integer) -> Options.genericValueLabel(component, Component.literal(integer.toString())),
                                 new OptionInstance.IntRange(0, 15),
                                 Codec.intRange(0, 15),
-                                Config.getBlockThreshold(),
-                                Config::setBlockThreshold
+                                Config.getOverworldBlockThreshold(),
+                                Config::setOverworldBlockThreshold
                         ),
                         new OptionInstance<>(
                                 "lighty.options.sky_threshold",
@@ -77,8 +77,8 @@ public class SettingsScreen extends Screen {
                                 (component, integer) -> Options.genericValueLabel(component, Component.literal(integer.toString())),
                                 new OptionInstance.IntRange(0, 15),
                                 Codec.intRange(0, 15),
-                                Config.getSkyThreshold(),
-                                Config::setSkyThreshold
+                                Config.getOverworldSkyThreshold(),
+                                Config::setOverworldSkyThreshold
                         ),
                         new OptionInstance<>(
                                 "lighty.options.farm_growth_threshold",


### PR DESCRIPTION
Suggested this in #57, and wanted to try to implement it.
The API now accepts dimension data.
Lighty modes now send dimension data to the API.
Since some values were being used multiple times, I decided to create a central variable for the methods that did so.
With the addition of dimension-specific thresholds, I decided to append "overworld_" to the start of the original threshold names.