### PR TITLE
Implemented a "show/hide skylight level" feature

### DIFF
--- a/common/src/main/java/dev/schmarrn/lighty/config/Config.java
+++ b/common/src/main/java/dev/schmarrn/lighty/config/Config.java
@@ -51,6 +51,8 @@ public class Config {
     public static final ResourceLocationConfig AUTO_ON_ITEM = new ResourceLocationConfig("lighty.auto_on.item", ResourceLocation.parse("minecraft:torch"));
     public static final BooleanConfig SHOULD_AUTO_ON = new BooleanConfig("lighty.auto_on", false);
 
+    public static final BooleanConfig SHOW_SKYLIGHT_LEVEL = new BooleanConfig("lighty.show_skylight_level", true);
+
     public static final ResourceLocationConfig CARPET_TEXTURE = new ResourceLocationConfig("lighty.mode.carpet.texture", ResourceLocation.fromNamespaceAndPath(Lighty.MOD_ID, "textures/block/transparent.png"));
     public static final ResourceLocationConfig CROSS_TEXTURE = new ResourceLocationConfig("lighty.mode.cross.texture", ResourceLocation.fromNamespaceAndPath(Lighty.MOD_ID, "textures/block/cross.png"));
 

--- a/common/src/main/java/dev/schmarrn/lighty/mode/NumberMode.java
+++ b/common/src/main/java/dev/schmarrn/lighty/mode/NumberMode.java
@@ -104,8 +104,12 @@ public class NumberMode extends LightyMode {
         int overlayBrightness = Config.OVERLAY_BRIGHTNESS.getValue();
         int lightmap = LightTexture.pack(overlayBrightness, overlayBrightness);
 
-        renderNumber(builder, blockLightLevel, x1, y, z1, color, lightmap);
-        renderNumber(builder, skyLightLevel, x1, y, z1 + 0.3f, color, lightmap);
+        if (Config.SHOW_SKYLIGHT_LEVEL.getValue()) {
+            renderNumber(builder, blockLightLevel, x1, y, z1, color, lightmap);
+            renderNumber(builder, skyLightLevel, x1, y, z1 + PXL * 6f, color, lightmap);
+        }
+        else
+            renderNumber(builder, blockLightLevel, x1, y, z1 + PXL * 2f, color, lightmap);
     }
 
     @Override

--- a/common/src/main/java/dev/schmarrn/lighty/ui/SettingsScreen.java
+++ b/common/src/main/java/dev/schmarrn/lighty/ui/SettingsScreen.java
@@ -46,6 +46,11 @@ public class SettingsScreen extends OptionsSubScreen {
         this.list.addSmall(
                 new OptionInstance[]{
                         Config.SHOW_SAFE.getOptionInstance(),
+                        Config.SHOW_SKYLIGHT_LEVEL.getOptionInstance()
+                }
+        );
+        this.list.addSmall(
+                new OptionInstance[]{
                         Config.SHOULD_AUTO_ON.getOptionInstance()
                 }
         );

--- a/common/src/main/resources/assets/lighty/lang/en_us.json
+++ b/common/src/main/resources/assets/lighty/lang/en_us.json
@@ -33,6 +33,8 @@
   "lighty.options.overlay_brightness.tooltip": "The brightness of the rendered overlay. Defaults to 10. Especially useful when using shaders.",
   "lighty.options.show_safe": "Show Safe Spots",
   "lighty.options.show_safe.tooltip": "If on, the overlay gets rendered on safe (green) spots.",
+  "lighty.options.show_skylight_level": "Show Skylight Level",
+  "lighty.options.show_skylight_level.tooltip": "If on, Number Mode shows both block-light and sky-light levels. (Default: ON)",
   "lighty.options.auto_on": "Auto-On",
   "lighty.options.auto_on.tooltip": "If on, the overlay gets enabled when holding an item of certain type. (Default: OFF, Default item: minecraft:torch)"
 }


### PR DESCRIPTION
Mentioned in https://github.com/SchmarrnDevs/Lighty/issues/66
Show/hide seemed easier to implement than resize. Also configurable in the settings screen.