### PR TITLE
Allow run configurations to be generated for the Fabric subproject

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,6 +33,9 @@ loom {
     mixin {
         defaultRefmapName.set("lighty.refmap.json")
     }
+    runConfigs.configureEach {
+        ideConfigGenerated = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds a Minecraft Client and Minecraft Server run configuration for being able to test Fabric without using yucky Gradle tasks.
<img width="753" height="196" alt="image" src="https://github.com/user-attachments/assets/d1d945ad-a84c-4baa-8801-97ecb9a190ca" />
