### PR TITLE
Clear compute cache on level load to prevent old buffers from appearing

### DIFF
--- a/fabric/src/main/java/dev/schmarrn/lighty/fabric/LightyFabric.java
+++ b/fabric/src/main/java/dev/schmarrn/lighty/fabric/LightyFabric.java
@@ -22,6 +22,7 @@ import dev.schmarrn.lighty.event.KeyBind;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.loader.api.FabricLoader;
 
@@ -33,6 +34,7 @@ public class LightyFabric implements ClientModInitializer {
         WorldRenderEvents.AFTER_TRANSLUCENT.register(context -> LightyRenderer.render(context.frustum()));
 
         ClientTickEvents.END_CLIENT_TICK.register(KeyBind::handleKeyBind);
+        ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE.register((minecraft, level) -> Compute.clear());
 
         Lighty.init();
         FabricLoader.getInstance().getEntrypoints("lightyModesRegistration", LightyModesRegistration.class).forEach(LightyModesRegistration::registerLightyModes);

--- a/neoforge/src/main/java/dev/schhmarrn/lighty/forge/LightyForge.java
+++ b/neoforge/src/main/java/dev/schhmarrn/lighty/forge/LightyForge.java
@@ -28,6 +28,7 @@ import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
 
 @Mod(value = Lighty.MOD_ID, dist = Dist.CLIENT)
 public class LightyForge {
@@ -47,6 +48,11 @@ public class LightyForge {
         @SubscribeEvent
         public static void loadComplete(FMLLoadCompleteEvent event) {
             Lighty.postLoad();
+        }
+
+        @SubscribeEvent
+        public static void Load(LevelEvent.Load event) {
+            Compute.clear();
         }
     }
 


### PR DESCRIPTION
Fixes #93