### PR TITLE
Replace outdated wiki link in comment

### DIFF
--- a/common/src/main/java/dev/schmarrn/lighty/api/LightyHelper.java
+++ b/common/src/main/java/dev/schmarrn/lighty/api/LightyHelper.java
@@ -67,7 +67,7 @@ public class LightyHelper {
     public static boolean isBlocked(BlockState block, BlockPos pos, ClientLevel world, LevelChunk chunk) {
         BlockPos posUp = pos.above();
         BlockState blockStateUp = chunk.getBlockState(posUp);
-        // Resource: https://minecraft.fandom.com/wiki/Tutorials/Spawn-proofing
+        // Resource: https://minecraft.wiki/w/Tutorial:Spawn-proofing
         return (blockStateUp.isCollisionShapeFullBlock(chunk, posUp) || // Full blocks are not spawnable in
                 !block.isFaceSturdy(chunk, pos, Direction.UP) || // Block below needs to be sturdy
                 isRedstone(blockStateUp.getBlock()) || // Mobs don't spawn in redstone


### PR DESCRIPTION
This is the only outdated link I could find in the codebase. Replace old minecraft.fandom.com with minecraft.wiki.